### PR TITLE
Fix reference to unsupported connection type

### DIFF
--- a/doc/src/Developer_Quick_Start.rst
+++ b/doc/src/Developer_Quick_Start.rst
@@ -107,7 +107,7 @@ concludes by showing how to query the database using LINQ::
           {
 
               // define a connection string
-              const string connectionString = "type=http;endpoint=http://localhost:8090/brightstar;storeName=Films";
+              const string connectionString = "type=embedded;storesdirectory=.\\;storename=Films";
 
 
               // if the store does not exist it will be automatically 


### PR DESCRIPTION
As of version 1.5 http type for the connection string is no longer supported.  The docs referred to this superseded connection type.  The connection string in this example now uses an embedded database in a local directory.
