### PR TITLE
Added changes for loading entities from triples sparql result, createt m...

### DIFF
--- a/src/core/BrightstarDB.EntityFramework.Tests/ConstructorTests.cs
+++ b/src/core/BrightstarDB.EntityFramework.Tests/ConstructorTests.cs
@@ -31,18 +31,18 @@ namespace BrightstarDB.EntityFramework.Tests
 ?c <http://www.networkedplanet.com/schemas/test/ticker> ?v1 .
 ?c <http://www.networkedplanet.com/schemas/test/price> ?v2 .}"
                 );
-            Assert.IsNotNull(Context.LastSparqlQueryContext.Constructor);
-            Assert.AreEqual(typeof(StockQuote), Context.LastSparqlQueryContext.Constructor.DeclaringType);
-            Assert.AreEqual(0, Context.LastSparqlQueryContext.Constructor.GetParameters().Count());
-            Assert.AreEqual(0, Context.LastSparqlQueryContext.ConstructorArgs.Count);
-            Assert.AreEqual(2, Context.LastSparqlQueryContext.MemberAssignment.Count);
+            Assert.IsNotNull(Context.LastSparqlLinqQueryContext.Constructor);
+            Assert.AreEqual(typeof(StockQuote), Context.LastSparqlLinqQueryContext.Constructor.DeclaringType);
+            Assert.AreEqual(0, Context.LastSparqlLinqQueryContext.Constructor.GetParameters().Count());
+            Assert.AreEqual(0, Context.LastSparqlLinqQueryContext.ConstructorArgs.Count);
+            Assert.AreEqual(2, Context.LastSparqlLinqQueryContext.MemberAssignment.Count);
             var tickerAssignment =
-                Context.LastSparqlQueryContext.MemberAssignment.Where(ma => ma.Item1.Name.Equals("Ticker")).
+                Context.LastSparqlLinqQueryContext.MemberAssignment.Where(ma => ma.Item1.Name.Equals("Ticker")).
                     FirstOrDefault();
             Assert.IsNotNull(tickerAssignment);
             Assert.AreEqual("v1", tickerAssignment.Item2);
             var priceAssignment =
-                Context.LastSparqlQueryContext.MemberAssignment.Where(ma => ma.Item1.Name.Equals("Price")).
+                Context.LastSparqlLinqQueryContext.MemberAssignment.Where(ma => ma.Item1.Name.Equals("Price")).
                     FirstOrDefault();
             Assert.IsNotNull(priceAssignment);
             Assert.AreEqual("v2", priceAssignment.Item2);

--- a/src/core/BrightstarDB.EntityFramework.Tests/LinqToSparqlTests.cs
+++ b/src/core/BrightstarDB.EntityFramework.Tests/LinqToSparqlTests.cs
@@ -445,7 +445,7 @@ OPTIONAL { ?x <http://purl.org/dc/terms/title> ?v0 . }
 OPTIONAL { ?x <http://www.networkedplanet.com/schemas/test/ticker> ?v1 . }
 OPTIONAL { ?v2 <http://www.networkedplanet.com/schemas/test/listing> ?x .
            ?v2 <http://purl.org/dc/terms/title> ?v3 . } }");
-            Assert.AreEqual("v3", Context.LastSparqlQueryContext.AnonymousMembersMap.Where(x=>x.Item1.Equals("Market")).Select(x=>x.Item2).FirstOrDefault());
+            Assert.AreEqual("v3", Context.LastSparqlLinqQueryContext.AnonymousMembersMap.Where(x=>x.Item1.Equals("Market")).Select(x=>x.Item2).FirstOrDefault());
 
             var r = from x in Context.Companies select new { x.Name, x.TickerSymbol, Market = x.ListedOn };
             r.ToList();

--- a/src/core/BrightstarDB.EntityFramework.Tests/MockContext.cs
+++ b/src/core/BrightstarDB.EntityFramework.Tests/MockContext.cs
@@ -16,9 +16,9 @@ namespace BrightstarDB.EntityFramework.Tests
     public class MockContext : EntityContext
     {
         private string _lastQuery;
-        private SparqlQueryContext _lastQueryContext;
+        private SparqlLinqQueryContext _lastLinqQueryContext;
         public string LastSparqlQuery { get { return _lastQuery; } }
-        public SparqlQueryContext LastSparqlQueryContext { get { return _lastQueryContext; } }
+        public SparqlLinqQueryContext LastSparqlLinqQueryContext { get { return _lastLinqQueryContext; } }
 
         public MockContext() : base()
         {
@@ -69,17 +69,17 @@ namespace BrightstarDB.EntityFramework.Tests
             return new XDocument();
         }
 
-        public override IEnumerable<T> ExecuteQuery<T>(SparqlQueryContext sparqlQuery)
+        public override IEnumerable<T> ExecuteQuery<T>(SparqlLinqQueryContext sparqlLinqQuery)
         {
-            _lastQuery = sparqlQuery.SparqlQuery;
-            _lastQueryContext = sparqlQuery;
+            _lastQuery = sparqlLinqQuery.SparqlQuery;
+            _lastLinqQueryContext = sparqlLinqQuery;
             yield break;
         }
 
         public override IEnumerable<T> ExecuteInstanceQuery<T>(string instanceIdentifier, string typeIdentifier)
         {
             _lastQuery = String.Format("ASK {{ <{0}> a <{1}>. }}", instanceIdentifier, typeIdentifier);
-            _lastQueryContext = null;
+            _lastLinqQueryContext = null;
             yield break;
         }
 

--- a/src/core/BrightstarDB.OData/BrightstarDB.OData.csproj
+++ b/src/core/BrightstarDB.OData/BrightstarDB.OData.csproj
@@ -199,7 +199,7 @@
         <WebProjectProperties>
           <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>27588</DevelopmentServerPort>
+          <DevelopmentServerPort>9310</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>
           </IISUrl>

--- a/src/core/BrightstarDB/BrightstarDB.csproj
+++ b/src/core/BrightstarDB/BrightstarDB.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Dto\TransactionStatus.cs" />
     <Compile Include="Dto\TransactionType.cs" />
     <Compile Include="EntityFramework\IBrightstarEntityCollection.cs" />
+    <Compile Include="EntityFramework\Query\SparqlQueryContext.cs" />
     <Compile Include="FormatInfo.cs" />
     <Compile Include="ISerializationFormat.cs" />
     <Compile Include="NoAcceptableFormatException.cs" />
@@ -233,7 +234,7 @@
     <Compile Include="EntityFramework\Query\SparqlGeneratorWhereExpressionTreeVisitor.cs" />
     <Compile Include="EntityFramework\Query\SparqlOrdering.cs" />
     <Compile Include="EntityFramework\Query\SparqlQueryBuilder.cs" />
-    <Compile Include="EntityFramework\Query\SparqlQueryContext.cs" />
+    <Compile Include="EntityFramework\Query\SparqlLinqQueryContext.cs" />
     <Compile Include="EntityFramework\Query\TripleInfo.cs" />
     <Compile Include="EntityFramework\Query\VariableBindingType.cs" />
     <Compile Include="EntityFramework\ReflectionMappingException.cs" />

--- a/src/core/BrightstarDB/Client/DataObject.cs
+++ b/src/core/BrightstarDB/Client/DataObject.cs
@@ -149,6 +149,16 @@ namespace BrightstarDB.Client
         }
 
         /// <summary>
+        /// Gets the uri types of this data object
+        /// </summary>
+        /// <returns>A list of uri types</returns>
+        public IList<string> GetTypes()
+        {
+            return this.Triples.Where(t => t.Predicate == TypeDataObject.Identity).Select(t => t.Object).ToList();
+        }
+
+
+        /// <summary>
         /// Sets the property of this object to the specified value
         /// </summary>
         /// <param name="type">The type of the property to set</param>

--- a/src/core/BrightstarDB/Client/DataObjectStoreBase.cs
+++ b/src/core/BrightstarDB/Client/DataObjectStoreBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using BrightstarDB.EntityFramework.Query;
 using BrightstarDB.Model;
 #if PORTABLE
 using BrightstarDB.Portable.Compatibility;
@@ -219,7 +220,12 @@ namespace BrightstarDB.Client
 
         public abstract IDataObject GetDataObject(string identity);
         public abstract IEnumerable<IDataObject> BindDataObjectsWithSparql(string sparqlExpression);
-        public abstract SparqlResult ExecuteSparql(string sparqlExpression);
+
+        public SparqlResult ExecuteSparql(string sparqlQuery)
+        {
+            return this.ExecuteSparql(new SparqlQueryContext(sparqlQuery));
+        }
+        public abstract SparqlResult ExecuteSparql(SparqlQueryContext sparqlQueryContext);
 
         /// <summary>
         /// Commits all changes. Waits for the operation to complete.
@@ -255,7 +261,7 @@ namespace BrightstarDB.Client
             {
                 // We just lookup the new version number
                 UpdateVersionFromSparqlResult(
-                    ExecuteSparql(String.Format(GetVersionSparql, dataObject.Identity)),
+                    ExecuteSparql(new SparqlQueryContext(String.Format(GetVersionSparql, dataObject.Identity))),
                     dataObject);
             }
             else

--- a/src/core/BrightstarDB/Client/EmbeddedDataObjectStore.cs
+++ b/src/core/BrightstarDB/Client/EmbeddedDataObjectStore.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using BrightstarDB.Dto;
+using BrightstarDB.EntityFramework.Query;
 using BrightstarDB.Model;
 using BrightstarDB.Rdf;
 using BrightstarDB.Server;
@@ -48,16 +49,16 @@ namespace BrightstarDB.Client
         public override IEnumerable<IDataObject> BindDataObjectsWithSparql(string sparqlExpression)
         {
             var helper = new SparqlResultDataObjectHelper(this);
-            return helper.BindDataObjects(ExecuteSparql(sparqlExpression));
+            return helper.BindDataObjects(ExecuteSparql(new SparqlQueryContext(sparqlExpression)));
         }
 
-        public override SparqlResult ExecuteSparql(string sparqlExpression)
+        public override SparqlResult ExecuteSparql(SparqlQueryContext sparqlQueryContext)
         {
             var resultStream = new MemoryStream();
-            _serverCore.Query(_storeName, sparqlExpression, DataSetGraphUris, null, SparqlResultsFormat.Xml,
+            _serverCore.Query(_storeName, sparqlQueryContext.SparqlQuery, DataSetGraphUris, null, SparqlResultsFormat.Xml,
                               RdfFormat.RdfXml, resultStream);
             resultStream.Seek(0, SeekOrigin.Begin);
-            return new SparqlResult(resultStream);
+            return new SparqlResult(resultStream, sparqlQueryContext);
         }
 
         public override bool BindDataObject(DataObject dataObject)

--- a/src/core/BrightstarDB/Client/IDataObject.cs
+++ b/src/core/BrightstarDB/Client/IDataObject.cs
@@ -33,6 +33,12 @@ namespace BrightstarDB.Client
         IDataObject SetType(IDataObject type);
 
         /// <summary>
+        /// Gets the type of this data object
+        /// </summary>
+        /// <returns>A list of object types</returns>
+        IList<string> GetTypes();
+
+        /// <summary>
         /// Sets the property of this object to the specified value
         /// </summary>
         /// <param name="type">The type of the property to set</param>

--- a/src/core/BrightstarDB/Client/IDataObjectStore.cs
+++ b/src/core/BrightstarDB/Client/IDataObjectStore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using BrightstarDB.EntityFramework.Query;
 
 namespace BrightstarDB.Client
 {
@@ -62,9 +63,16 @@ namespace BrightstarDB.Client
         /// <summary>
         /// Executes a SPARQL query against the underlying Brightstar store.
         /// </summary>
-        /// <param name="sparqlExpression">The SPARQL query to execute</param>
+        /// <param name="sparqlQuery">The SPARQL query to execute</param>
         /// <returns>The query result object</returns>
-        SparqlResult ExecuteSparql(string sparqlExpression);
+        SparqlResult ExecuteSparql(string sparqlQuery);
+
+        /// <summary>
+        /// Executes a SPARQL query against the underlying Brightstar store.
+        /// </summary>
+        /// <param name="sparqlQueryContext">The SPARQL query to execute</param>
+        /// <returns>The query result object</returns>
+        SparqlResult ExecuteSparql(SparqlQueryContext sparqlQueryContext);
 
         /// <summary>
         /// Commits all changes. Waits for the operation to complete.

--- a/src/core/BrightstarDB/Client/RemoteDataObjectStore.cs
+++ b/src/core/BrightstarDB/Client/RemoteDataObjectStore.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using BrightstarDB.EntityFramework.Query;
 using BrightstarDB.Model;
 using BrightstarDB.Rdf;
 
@@ -53,12 +54,12 @@ namespace BrightstarDB.Client
         public override IEnumerable<IDataObject> BindDataObjectsWithSparql(string sparqlExpression)
         {
             var binder = new SparqlResultDataObjectHelper(this);
-            return binder.BindDataObjects(ExecuteSparql(sparqlExpression));
+            return binder.BindDataObjects(ExecuteSparql(new SparqlQueryContext(sparqlExpression)));
         }
 
-        public override SparqlResult ExecuteSparql(string sparqlExpression)
+        public override SparqlResult ExecuteSparql(SparqlQueryContext sparqlQueryContext)
         {
-            return new SparqlResult(Client.ExecuteQuery(sparqlExpression, DataSetGraphUris));
+            return new SparqlResult(Client.ExecuteQuery(sparqlQueryContext.SparqlQuery, DataSetGraphUris), sparqlQueryContext);
         }
 
         protected virtual string GetQueryTemplate()

--- a/src/core/BrightstarDB/Client/SparqlResult.cs
+++ b/src/core/BrightstarDB/Client/SparqlResult.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Xml.Linq;
+using BrightstarDB.EntityFramework.Query;
 
 namespace BrightstarDB.Client
 {
@@ -13,14 +14,21 @@ namespace BrightstarDB.Client
         private Stream _resultStream;
         private readonly string _resultString;
 
-        internal SparqlResult(Stream resultStream)
+        /// <summary>
+        /// The SparqlQueryContext that generated this result
+        /// </summary>
+        public readonly SparqlQueryContext SourceSparqlQueryContext;
+
+        internal SparqlResult(Stream resultStream, SparqlQueryContext sparqlQueryContext)
         {
             _resultStream = resultStream;
+            SourceSparqlQueryContext = sparqlQueryContext;
         }
 
-        internal SparqlResult(string xml)
+        internal SparqlResult(string xml, SparqlQueryContext sparqlQueryContext)
         {
             _resultString = xml;
+            SourceSparqlQueryContext = sparqlQueryContext;
         }
 
         /// <summary>

--- a/src/core/BrightstarDB/Dynamic/DynamicStore.cs
+++ b/src/core/BrightstarDB/Dynamic/DynamicStore.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using BrightstarDB.Client;
+using BrightstarDB.EntityFramework.Query;
 
 namespace BrightstarDB.Dynamic
 {

--- a/src/core/BrightstarDB/EntityFramework/EntityContext.cs
+++ b/src/core/BrightstarDB/EntityFramework/EntityContext.cs
@@ -75,9 +75,9 @@ namespace BrightstarDB.EntityFramework
         /// Method to execute a SPARQL query against the underlying store and bind its results to instances of a class
         /// </summary>
         /// <typeparam name="T">The type that the SPARQL query results are to be bound to</typeparam>
-        /// <param name="sparqlQueryContext">The context object that specifies the SPARQL query and constructor and member mappings</param>
+        /// <param name="sparqlLinqQueryContext">The context object that specifies the SPARQL query and constructor and member mappings</param>
         /// <returns>An enumeration over the bound result objects</returns>
-        public abstract IEnumerable<T> ExecuteQuery<T>(SparqlQueryContext sparqlQueryContext);
+        public abstract IEnumerable<T> ExecuteQuery<T>(SparqlLinqQueryContext sparqlLinqQueryContext);
 
         /// <summary>
         /// Handler for the special case query that selects a specific instance of a type
@@ -121,6 +121,16 @@ namespace BrightstarDB.EntityFramework
         public Type GetImplType(Type interfaceType)
         {
             return Mappings.GetImplType(interfaceType);
+        }
+
+        /// <summary>
+        /// Returns the entity implementation type for a given uri
+        /// </summary>
+        /// <param name="typeUri">The uri representing a resource type.</param>
+        /// <returns>The entity implementation type</returns>
+        public Type GetTypeForUri(string typeUri)
+        {
+            return Mappings.GetImplTypeForUri(typeUri);
         }
 
         /// <summary>

--- a/src/core/BrightstarDB/EntityFramework/EntityMappingStore.cs
+++ b/src/core/BrightstarDB/EntityFramework/EntityMappingStore.cs
@@ -195,6 +195,19 @@ namespace BrightstarDB.EntityFramework
         }
 
         /// <summary>
+        /// Returns the entity implementation type for a given uri
+        /// </summary>
+        /// <param name="typeUri">The uri representing a resource type.</param>
+        /// <returns>The entity implementation type</returns>
+        public Type GetImplTypeForUri(string typeUri)
+        {
+            Type domainType = _typeMappings.FirstOrDefault(x => x.Value == typeUri).Key;
+            if (domainType == null) return null;
+            Type implType = GetImplType(domainType);
+            return implType;
+        }
+
+        /// <summary>
         /// Returns the entity implementation type for a specific entity interface type
         /// </summary>
         /// <param name="interfaceType">The entity interface type</param>

--- a/src/core/BrightstarDB/EntityFramework/Query/EntityFrameworkCollectionQueryExecutor.cs
+++ b/src/core/BrightstarDB/EntityFramework/Query/EntityFrameworkCollectionQueryExecutor.cs
@@ -87,7 +87,7 @@ namespace BrightstarDB.EntityFramework.Query
         /// </returns>
         public IEnumerable<T> ExecuteCollection<T>(QueryModel queryModel)
         {
-            var sparqlQuery = SparqlGeneratorQueryModelVisitor.GenerateSparqlQuery(_context);
+            var sparqlQuery = SparqlGeneratorQueryModelVisitor.GenerateSparqlLinqQuery(_context);
             return sparqlQuery.IsInstanceQuery
                        ? _context.ExecuteInstanceQuery<T>(sparqlQuery.InstanceUri, sparqlQuery.TypeUri)
                        : _context.ExecuteQuery<T>(sparqlQuery);

--- a/src/core/BrightstarDB/EntityFramework/Query/EntityFrameworkQueryExecutor.cs
+++ b/src/core/BrightstarDB/EntityFramework/Query/EntityFrameworkQueryExecutor.cs
@@ -79,7 +79,7 @@ namespace BrightstarDB.EntityFramework.Query
         /// </returns>
         public IEnumerable<T> ExecuteCollection<T>(QueryModel queryModel)
         {
-            var sparqlQuery = SparqlGeneratorQueryModelVisitor.GenerateSparqlQuery(_context, queryModel);
+            var sparqlQuery = SparqlGeneratorQueryModelVisitor.GenerateSparqlLinqQuery(_context, queryModel);
             return sparqlQuery.IsInstanceQuery
                        ? _context.ExecuteInstanceQuery<T>(sparqlQuery.InstanceUri, sparqlQuery.TypeUri)
                        : _context.ExecuteQuery<T>(sparqlQuery);

--- a/src/core/BrightstarDB/EntityFramework/Query/SparqlGeneratorQueryModelVisitor.cs
+++ b/src/core/BrightstarDB/EntityFramework/Query/SparqlGeneratorQueryModelVisitor.cs
@@ -15,7 +15,7 @@ namespace BrightstarDB.EntityFramework.Query
         private string _instanceUri;
         private string _typeUri;
 
-        public static SparqlQueryContext GenerateSparqlQuery(EntityContext context, QueryModel queryModel)
+        public static SparqlLinqQueryContext GenerateSparqlLinqQuery(EntityContext context, QueryModel queryModel)
         {
             var visitor = new SparqlGeneratorQueryModelVisitor(context);
             visitor.VisitQueryModel(queryModel);
@@ -387,14 +387,14 @@ namespace BrightstarDB.EntityFramework.Query
             return null;
         }
 
-        public SparqlQueryContext GetSparqlQuery(bool useDescribe)
+        public SparqlLinqQueryContext GetSparqlQuery(bool useDescribe)
         {
             if (_isInstanceQuery)
             {
-                return new SparqlQueryContext(_instanceUri, _typeUri);
+                return new SparqlLinqQueryContext(_instanceUri, _typeUri);
             }
             return
-                new SparqlQueryContext(
+                new SparqlLinqQueryContext(
                     useDescribe && !_queryBuilder.IsDistinct && !_queryBuilder.IsOrdered
                         ? _queryBuilder.GetSparqlDescribeString()
                         : _queryBuilder.GetSparqlString(),

--- a/src/core/BrightstarDB/EntityFramework/Query/SparqlLinqQueryContext.cs
+++ b/src/core/BrightstarDB/EntityFramework/Query/SparqlLinqQueryContext.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace BrightstarDB.EntityFramework.Query
+{
+    /// <summary>
+    /// Manages the context information required during the processing of an entity framework LINQ query into SPARQL
+    /// </summary>
+    public class SparqlLinqQueryContext : SparqlQueryContext
+    {
+        /// <summary>
+        /// Get the flag that indicates if this query is a simple type-instance query
+        /// which can have optimised processing
+        /// </summary>
+        public bool IsInstanceQuery { get; private set; }
+        /// <summary>
+        /// Get the instance URI in the type-instance query
+        /// </summary>
+        /// <remarks>This property is valid iff <see cref="IsInstanceQuery"/> is true</remarks>
+        public string InstanceUri { get; private set; }
+        /// <summary>
+        /// Get the type URI in the type-instance query
+        /// </summary>
+        /// <remarks>This property is valid iff <see cref="IsInstanceQuery"/> is true</remarks>
+        public string TypeUri { get; private set; }
+       
+        /// <summary>
+        /// Gets the constructor to be invoked when binding SPARQL query results to LINQ query results
+        /// </summary>
+        public ConstructorInfo Constructor { get; private set; }
+        /// <summary>
+        /// Gets the list of SPARQL query variables whose values are to be passed as variables into <see cref="Constructor"/> when binding SPARQL query results to LINQ query results
+        /// </summary>
+        public List<string> ConstructorArgs { get; private set; }
+        /// <summary>
+        /// Gets the list of tuples that map LINQ result instance members to the SPARQL variable that provides the value for that instance
+        /// </summary>
+        public List<Tuple<MemberInfo, string>> MemberAssignment { get; private set; }
+
+        private readonly Expression _memberInitExpression;
+
+        internal SparqlLinqQueryContext(string instanceUri, string typeUri) :base()
+        {
+            IsInstanceQuery = true;
+            InstanceUri = instanceUri;
+            TypeUri = typeUri;
+        }
+
+        ///<summary>
+        /// Creates a new query context instance
+        ///</summary>
+        ///<param name="sparqlQuery">The SPARQL query to be executed</param>
+        ///<param name="anonymousMembersMap">A list of tuples that bind the names of the anonymous result types members to the SPARQL variable that provides the value for that member</param>
+        ///<param name="constructor">The constructor to invoke to bind a SPARQL results row to a result object</param>
+        ///<param name="constructorArgs">A list of the SPARQL bindings that are to be passed into the constructor</param>
+        ///<param name="memberMap">A list of tuples that bind the names of result object members to the SPARQL variables that provides the value for the member</param>
+        ///<param name="memberInitExpression">A LINQ expression that is used to initialize the members of the results object from a SPARQL results row</param>
+        public SparqlLinqQueryContext(string sparqlQuery, List<Tuple<string, string>> anonymousMembersMap, 
+            ConstructorInfo constructor, List<string> constructorArgs, List<Tuple<MemberInfo, string>> memberMap,
+            Expression memberInitExpression) :base(sparqlQuery, anonymousMembersMap)
+        {
+            IsInstanceQuery = false;
+            Constructor = constructor;
+            ConstructorArgs = constructorArgs;
+            MemberAssignment = memberMap;
+            _memberInitExpression = memberInitExpression;
+        }
+
+        /// <summary>
+        /// Returns true if the LINQ query uses an expression to initialize the results members
+        /// </summary>
+        public bool HasMemberInitExpression { get { return _memberInitExpression != null; } }
+
+        /// <summary>
+        /// Applies the LINQ expression used to initialize result members to a SPARQL result binding
+        /// </summary>
+        /// <typeparam name="T">The type of item to be initialized</typeparam>
+        /// <param name="parameters">The SPARLQ result binding values</param>
+        /// <param name="converter">A function that given a string value from the SPARQL binding and a target type is capable of returning a new instance of the target type bound to the string value</param>
+        /// <returns>The generated member instance</returns>
+        public object ApplyMemberInitExpression<T>(Dictionary<string, object> parameters, Func<string, string, Type, object> converter )
+        {
+            var exprBuilder = new SparqlGeneratorSelectExpressionBuilder(parameters, converter);
+            var expressionBody = exprBuilder.VisitExpression(_memberInitExpression);
+            Expression<Func<T>> lambdaWithoutParameters = Expression.Lambda<Func<T>>(expressionBody);
+            return lambdaWithoutParameters.Compile()();
+        }
+
+        /// <summary>
+        /// Applies the <see cref="Constructor"/> and <see cref="MemberAssignment"/> information to bind
+        /// a SPARQL results row to a new LINQ result object
+        /// </summary>
+        /// <param name="values">The SPARQL results row</param>
+        /// <returns>The new LINQ result object</returns>
+        public object MapRow(Dictionary<string, object> values)
+        {
+            object ret = null;
+            if (Constructor != null)
+            {
+                if (Constructor.GetParameters().Count() == 0)
+                {
+                    ret = Constructor.Invoke(new object[0]);
+                }
+                else
+                {
+                    var ctorParams = ConstructorArgs.Select(ca => values[ca]).ToArray();
+                    ret = Constructor.Invoke(ctorParams);
+                }
+            }
+            if (ret != null)
+            {
+                foreach (var mapping in MemberAssignment)
+                {
+                    if (values.ContainsKey(mapping.Item2))
+                    {
+#if PORTABLE
+                        var memberInfo =
+                            Constructor.DeclaringType.GetMember(mapping.Item1.Name, BindingFlags.Public).FirstOrDefault();
+                        if (memberInfo != null)
+                        {
+                            var methodInfo = memberInfo as MethodInfo;
+                            methodInfo.Invoke(ret, new []{values[mapping.Item2]});
+                        }
+#else
+                        Constructor.DeclaringType.InvokeMember(mapping.Item1.Name, BindingFlags.Public, null, ret,
+                                                               new object[] {values[mapping.Item2]});
+#endif
+                    }
+                }
+            }
+            return ret;
+        }
+    }
+
+}

--- a/src/core/BrightstarDB/EntityFramework/Query/SparqlQueryContext.cs
+++ b/src/core/BrightstarDB/EntityFramework/Query/SparqlQueryContext.cs
@@ -1,31 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
+using System.Text;
 
 namespace BrightstarDB.EntityFramework.Query
 {
     /// <summary>
-    /// Manages the context information required during the processing of an entity framework LINQ query into SPARQL
+    /// Manages the context information required during the processing of an entity framework query into SPARQL
     /// </summary>
     public class SparqlQueryContext
     {
-        /// <summary>
-        /// Get the flag that indicates if this query is a simple type-instance query
-        /// which can have optimised processing
-        /// </summary>
-        public bool IsInstanceQuery { get; private set; }
-        /// <summary>
-        /// Get the instance URI in the type-instance query
-        /// </summary>
-        /// <remarks>This property is valid iff <see cref="IsInstanceQuery"/> is true</remarks>
-        public string InstanceUri { get; private set; }
-        /// <summary>
-        /// Get the type URI in the type-instance query
-        /// </summary>
-        /// <remarks>This property is valid iff <see cref="IsInstanceQuery"/> is true</remarks>
-        public string TypeUri { get; private set; }
         /// <summary>
         /// Get the SPARQL query that is generated from the LINQ
         /// </summary>
@@ -34,115 +18,34 @@ namespace BrightstarDB.EntityFramework.Query
         /// Gets the list of tuples that map anonymous type members in the LINQ query result to SPARQL variables in the SPARQL query result
         /// </summary>
         public List<Tuple<string, string>> AnonymousMembersMap { get; private set; }
-        /// <summary>
-        /// Gets the constructor to be invoked when binding SPARQL query results to LINQ query results
-        /// </summary>
-        public ConstructorInfo Constructor { get; private set; }
-        /// <summary>
-        /// Gets the list of SPARQL query variables whose values are to be passed as variables into <see cref="Constructor"/> when binding SPARQL query results to LINQ query results
-        /// </summary>
-        public List<string> ConstructorArgs { get; private set; }
-        /// <summary>
-        /// Gets the list of tuples that map LINQ result instance members to the SPARQL variable that provides the value for that instance
-        /// </summary>
-        public List<Tuple<MemberInfo, string>> MemberAssignment { get; private set; }
 
-        private readonly Expression _memberInitExpression;
+        /// <summary>
+        /// If true the result is expected to have triples and their subjects grouped.For each subject group a new entity is created.
+        /// </summary>
+        public bool ExpectTriplesWithOrderedSubjects { get; set; }
 
-        internal SparqlQueryContext(string instanceUri, string typeUri)
+        internal SparqlQueryContext()
         {
-            IsInstanceQuery = true;
-            InstanceUri = instanceUri;
-            TypeUri = typeUri;
             AnonymousMembersMap = new List<Tuple<string, string>>();
         }
 
-        ///<summary>
-        /// Creates a new query context instance
-        ///</summary>
-        ///<param name="sparqlQuery">The SPARQL query to be executed</param>
-        ///<param name="anonymousMembersMap">A list of tuples that bind the names of the anonymous result types members to the SPARQL variable that provides the value for that member</param>
-        ///<param name="constructor">The constructor to invoke to bind a SPARQL results row to a result object</param>
-        ///<param name="constructorArgs">A list of the SPARQL bindings that are to be passed into the constructor</param>
-        ///<param name="memberMap">A list of tuples that bind the names of result object members to the SPARQL variables that provides the value for the member</param>
-        ///<param name="memberInitExpression">A LINQ expression that is used to initialize the members of the results object from a SPARQL results row</param>
-        public SparqlQueryContext(string sparqlQuery, List<Tuple<string, string>> anonymousMembersMap, 
-            ConstructorInfo constructor, List<string> constructorArgs, List<Tuple<MemberInfo, string>> memberMap,
-            Expression memberInitExpression)
+        /// <summary>
+        /// Creates a new SparqlQueryContext instance
+        /// </summary>
+        /// <param name="sparqlQuery">sparql query</param>
+        public SparqlQueryContext(string sparqlQuery)
         {
-            IsInstanceQuery = false;
             SparqlQuery = sparqlQuery;
+        }
+
+        /// <summary>
+        /// Creates a new SparqlQueryContext instance
+        /// </summary>
+        /// <param name="sparqlQuery">sparql query</param>
+        /// <param name="anonymousMembersMap">mappings for anonymous types</param>
+        public SparqlQueryContext(string sparqlQuery, List<Tuple<string, string>> anonymousMembersMap) :this(sparqlQuery)
+        {
             AnonymousMembersMap = anonymousMembersMap;
-            Constructor = constructor;
-            ConstructorArgs = constructorArgs;
-            MemberAssignment = memberMap;
-            _memberInitExpression = memberInitExpression;
-        }
-
-        /// <summary>
-        /// Returns true if the LINQ query uses an expression to initialize the results members
-        /// </summary>
-        public bool HasMemberInitExpression { get { return _memberInitExpression != null; } }
-
-        /// <summary>
-        /// Applies the LINQ expression used to initialize result members to a SPARQL result binding
-        /// </summary>
-        /// <typeparam name="T">The type of item to be initialized</typeparam>
-        /// <param name="parameters">The SPARLQ result binding values</param>
-        /// <param name="converter">A function that given a string value from the SPARQL binding and a target type is capable of returning a new instance of the target type bound to the string value</param>
-        /// <returns>The generated member instance</returns>
-        public object ApplyMemberInitExpression<T>(Dictionary<string, object> parameters, Func<string, string, Type, object> converter )
-        {
-            var exprBuilder = new SparqlGeneratorSelectExpressionBuilder(parameters, converter);
-            var expressionBody = exprBuilder.VisitExpression(_memberInitExpression);
-            Expression<Func<T>> lambdaWithoutParameters = Expression.Lambda<Func<T>>(expressionBody);
-            return lambdaWithoutParameters.Compile()();
-        }
-
-        /// <summary>
-        /// Applies the <see cref="Constructor"/> and <see cref="MemberAssignment"/> information to bind
-        /// a SPARQL results row to a new LINQ result object
-        /// </summary>
-        /// <param name="values">The SPARQL results row</param>
-        /// <returns>The new LINQ result object</returns>
-        public object MapRow(Dictionary<string, object> values)
-        {
-            object ret = null;
-            if (Constructor != null)
-            {
-                if (Constructor.GetParameters().Count() == 0)
-                {
-                    ret = Constructor.Invoke(new object[0]);
-                }
-                else
-                {
-                    var ctorParams = ConstructorArgs.Select(ca => values[ca]).ToArray();
-                    ret = Constructor.Invoke(ctorParams);
-                }
-            }
-            if (ret != null)
-            {
-                foreach (var mapping in MemberAssignment)
-                {
-                    if (values.ContainsKey(mapping.Item2))
-                    {
-#if PORTABLE
-                        var memberInfo =
-                            Constructor.DeclaringType.GetMember(mapping.Item1.Name, BindingFlags.Public).FirstOrDefault();
-                        if (memberInfo != null)
-                        {
-                            var methodInfo = memberInfo as MethodInfo;
-                            methodInfo.Invoke(ret, new []{values[mapping.Item2]});
-                        }
-#else
-                        Constructor.DeclaringType.InvokeMember(mapping.Item1.Name, BindingFlags.Public, null, ret,
-                                                               new object[] {values[mapping.Item2]});
-#endif
-                    }
-                }
-            }
-            return ret;
         }
     }
-
 }


### PR DESCRIPTION
Changed SparqlResultDataObjectHelper so now can load sparql query triples -> entities
Changed SparqlQueryContext -> SparqlLinqQueryContext; created new base class SparqlQueryContext to be used for custom queries
Added new context method "ExecuteQueryToResultTypes" that automatically maps triples info to entity types
Added unit tests
Refactored old Context "ExecuteQuery<T>" method code into separate methods.
Added DataObject method to get the entity type for a Uri ("http://.../Person" string -> Person c# type)
