### PR TITLE
All the EF samples failed in Mono

### DIFF
--- a/samples/Samples/Embedded/SamplesConfiguration.cs
+++ b/samples/Samples/Embedded/SamplesConfiguration.cs
@@ -14,7 +14,7 @@ namespace BrightstarDB.Samples
         /// OPTIONAL: If you would like the samples to store their data in a different folder, replace
         /// the value of this property with the path to use (the directory will be created if it does not exist)
         /// </summary>
-        public static string StoresDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\\BrightstarSamplesData";
+        public static string StoresDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "BrightstarSamplesData");
 
         public static void Register()
         {

--- a/src/core/BrightstarDB/Utils/XmlExtensions.cs
+++ b/src/core/BrightstarDB/Utils/XmlExtensions.cs
@@ -12,19 +12,35 @@ namespace BrightstarDB.Utils
     /// </summary>
     public static class XmlExtensions
     {
+        static bool IsRunningOnMono
+        {
+            get
+            {
+                return Type.GetType("Mono.Runtime") != null;
+            }
+        }
+
 #if !PORTABLE && !WINDOWS_PHONE
         /// <summary>
         /// Utility method to convert and XDocument to an XmlDocument
         /// </summary>
         /// <param name="document">The XDocument to be converted</param>
         /// <returns>The XmlDocument representation of the provided XDocument</returns>
-		public static XmlDocument AsXmlDocument(this XDocument document)
+        public static XmlDocument AsXmlDocument(this XDocument document)
         {
             var xmlDoc = new XmlDocument();
-            using (var xmlReader = document.CreateReader())
+            if (IsRunningOnMono)
             {
-                xmlDoc.Load(xmlReader);
+                xmlDoc.LoadXml(document.ToString());
             }
+            else
+            {
+                using (var xmlReader = document.CreateReader())
+                {
+                    xmlDoc.Load(xmlReader);
+                }
+            }
+
             return xmlDoc;
         }
 #endif


### PR DESCRIPTION
Change the SampleConfiguration to use `Path.Combine` instead of string concatenation. Added in XmlExtensions if is on mono to convert the `XDocument` to `XmlDocument` via `LoadXml` because with the reader there was an exception mono.

This line generates an exception https://github.com/BrightstarDB/BrightstarDB/blob/develop/src/core/BrightstarDB/Utils/XmlExtensions.cs#L26

``` cs
using (var xmlReader = document.CreateReader())
{
    xmlDoc.Load(xmlReader);
}
```

```
System.InvalidCastException: Cannot cast from source type to destination type.
  at System.Xml.Linq.XNodeReader.MoveToAttribute (System.String name) [0x00047] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.Xml.Linq/System.Xml.Linq/XNodeReader.cs:378
  at System.Xml.Linq.XNodeReader.GetAttribute (System.String name) [0x00015] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.Xml.Linq/System.Xml.Linq/XNodeReader.cs:447
  at System.Xml.XmlReader.get_Item (System.String name) [0x00000] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.XML/System.Xml/XmlReader.cs:161
  at System.Xml.XmlDocument.ReadNodeCore (System.Xml.XmlReader reader) [0x0025d] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.XML/System.Xml/XmlDocument.cs:978
  at System.Xml.XmlDocument.ReadNode (System.Xml.XmlReader reader) [0x00047] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.XML/System.Xml/XmlDocument.cs:874
  at System.Xml.XmlDocument.Load (System.Xml.XmlReader reader) [0x00019] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.XML/System.Xml/XmlDocument.cs:738
  at BrightstarDB.Utils.XmlExtensions.AsXmlDocument (System.Xml.Linq.XDocument document) [0x0002f] in /Users/jjchiw/github/BrightstarDB/src/core/BrightstarDB/Utils/XmlExtensions.cs:40
  at BrightstarDB.Client.SparqlResultDataObjectHelper+<BindRdfDataObjects>c__Iterator0.MoveNext () [0x0004d] in /Users/jjchiw/github/BrightstarDB/src/core/BrightstarDB/Client/SparqlResultDataObjectHelper.cs:55
  at BrightstarDB.EntityFramework.BrightstarEntityContext+<BindSparqlResultToKnownType>c__Iterator0`1[BrightstarDB.Samples.EntityFramework.GettingStarted.IActor].MoveNext () [0x000e4] in /Users/jjchiw/github/BrightstarDB/src/core/BrightstarDB/EntityFramework/BrightstarEntityContext.cs:433
  at System.Linq.Enumerable.First[IActor] (IEnumerable`1 source, System.Func`2 predicate, Fallback fallback) [0x0001f] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.Core/System.Linq/Enumerable.cs:825
  at System.Linq.Enumerable.FirstOrDefault[IActor] (IEnumerable`1 source) [0x00006] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.Core/System.Linq/Enumerable.cs:867
  at BrightstarDB.EntityFramework.Query.EntityFrameworkQueryExecutor.ExecuteSingle[IActor] (Remotion.Linq.QueryModel queryModel, Boolean returnDefaultWhenEmpty) [0x0002b] in /Users/jjchiw/github/BrightstarDB/src/core/BrightstarDB/EntityFramework/Query/EntityFrameworkQueryExecutor.cs:61
  at Remotion.Linq.Clauses.StreamedData.StreamedSingleValueInfo.ExecuteSingleQueryModel[IActor] (Remotion.Linq.QueryModel queryModel, IQueryExecutor executor) [0x00000] in <filename unknown>:0
  at Remotion.Linq.Clauses.StreamedData.StreamedSingleValueInfo.ExecuteQueryModel (Remotion.Linq.QueryModel queryModel, IQueryExecutor executor) [0x00000] in <filename unknown>:0
  at Remotion.Linq.QueryModel.Execute (IQueryExecutor executor) [0x00000] in <filename unknown>:0
  at Remotion.Linq.QueryProviderBase.Execute (System.Linq.Expressions.Expression expression) [0x00000] in <filename unknown>:0
  at Remotion.Linq.QueryProviderBase.System.Linq.IQueryProvider.Execute[IActor] (System.Linq.Expressions.Expression expression) [0x00000] in <filename unknown>:0
  at System.Linq.Queryable.FirstOrDefault[IActor] (IQueryable`1 source, System.Linq.Expressions.Expression`1 predicate) [0x00007] in /Volumes/build-root-ramdisk/mono-3.8.0/mcs/class/System.Core/System.Linq/Queryable.cs:610
  at BrightstarDB.Samples.EntityFramework.GettingStarted.Program.Main (System.String[] args) [0x001d6] in /Users/jjchiw/github/BrightstarDB/samples/Samples/Embedded/EntityFramework/GettingStarted/Program.cs:57
```

I fixed this way

``` cs
if (IsRunningOnMono) 
{
    xmlDoc.LoadXml(document.ToString());
} 
else 
{
    using (var xmlReader = document.CreateReader())
    {
        xmlDoc.Load(xmlReader);
    }
}
```

Using this helper method

``` cs
static bool IsRunningOnMono
{
    get 
    {
        return Type.GetType ("Mono.Runtime") != null;
    }
}
```

I didn't make any test if there is a penalty converting the `XDocument` to string and then load it to the `XmlDocument`.....
