### PR TITLE
Fix documentation typos

### DIFF
--- a/doc/src/Concepts.rst
+++ b/doc/src/Concepts.rst
@@ -37,7 +37,7 @@ The following diagram provides an overview of the BrightstarDB architecture.
  Data Model
 ***********
 
-BrightstarDB supports the `W3C RDF`_ and SPARQL 1.1 `Query`_ and `Update`_. 
+BrightstarDB supports the `W3C RDF`_ and SPARQL 1.1 `Query`_ and `Update`_ 
 standards, the data model stored is triples with a graph context (often this 
 is called a quad store). The triple data structure is very powerful, 
 especially for creating associative data models, merging data from many 
@@ -82,12 +82,12 @@ There are three different code layers with which to access BrightstarDB. The
 first of these is the :ref:`RDF Client API <RDF_Client_API>`. This is a low 
 level API that allows developers to insert and delete triples, and run SPARQL 
 queries. The second API layer is the :ref:`Data Object Layer 
-<Data_Object_Layer>`. This provides the ability to  treat a collection of 
+<Data_Object_Layer>`. This provides the ability to treat a collection of 
 triples with the same subject as a single unit and also provides support for 
 RDF list structures and optimistic locking. The highest API layer is the 
 :ref:`BrightstarDB Entity Framework <Entity_Framework>`. BrightstarDB enables 
 data-binding from items at the Data Object Layer to full .NET objects 
-described by a programmer-defined interface. As well as storing object state 
+described by a programmer-defined interface. As well as storing object state, 
 BrightstarDB also allows developers to use LINQ expressions to query the data 
 they have created.
 

--- a/doc/src/Developing_With_BrightstarDB.rst
+++ b/doc/src/Developing_With_BrightstarDB.rst
@@ -27,5 +27,5 @@ and take a walk through our :ref:`Developer Quick Start <Developer_Quick_Start>`
 you are already comfortable with RDF and SPARQL you may wish to start with the lower level APIs.
 
 If you are the kind of person that just likes to dive straight into sample code, please take a 
-moment to read about Running the BrightstarDB Samples first.
+moment to read about :ref:`Running the BrightstarDB Samples <Running_The_Samples>` first.
 

--- a/doc/src/Getting_Started.rst
+++ b/doc/src/Getting_Started.rst
@@ -57,14 +57,14 @@ Other sections of interest will probably be :ref:`SPARQL Endpoint
 
 
 BrightstarDB provides several layers of API that are aimed at specific 
-development activities or scenarios. There are three main API levels, Entity 
-Framework, Data Objects and RDF.
+development activities or scenarios. There are three main API levels: Entity 
+Framework, Data Objects, and RDF.
 
 **BrightstarDB Entity Framework & LINQ**
 
 The BrightstarDB Entity Framework is a powerful and simple to use technology 
 to quickly build a typed .NET domain model that can persist object state into 
-a BrightstarDB instance.To use this you create a set of .NET interfaces that 
+a BrightstarDB instance. To use this you create a set of .NET interfaces that 
 define the data model. The BrightstarDB tooling takes these definitions and 
 creates concrete implementing classes. These classes can then be used in an 
 application. The flexibility of the underlying storage makes evolving the 
@@ -89,7 +89,7 @@ documentation and examples of this APIs.
 
 **RDF & SPARQL**
 
-To work programmatically with RDF, SPARQL, and SPARQL see update the 
+To work programmatically with RDF, SPARQL query, and SPARQL update, see the 
 :ref:`RDF Client API <RDF_Client_API>` and :ref:`SPARQL Endpoint 
 <SPARQL_Endpoint>` sections. 
 

--- a/doc/src/Why_BrightstarDB_.rst
+++ b/doc/src/Why_BrightstarDB_.rst
@@ -43,7 +43,7 @@ networks, or any graph like data structure.
 
 The associative model used in BrightstarDB means data can be inserted into a 
 BrightstarDB database without the need to define a traditional database 
-schema. This further enhances flexibility and supports solution evolution 
+schema. This further enhances flexibility and supports solution evolution, 
 which is a critical feature of modern software solutions. 
 
 While the schema-less data store enables data of any shape to be imported and 
@@ -114,8 +114,8 @@ the same semantic data model.
 **********************************
 
 If you are working on .NET and want the power and flexibility of a semantic 
-web data store. Then BrightstarDB is a great place to start. With support for 
-the SPARQL query language and also the NTriples data format building semantic 
+web data store then BrightstarDB is a great place to start. With support for 
+the SPARQL query language and also the NTriples data format, building semantic 
 web based applications is simple and fun with BrightstarDB.
 
 
@@ -125,12 +125,12 @@ web based applications is simple and fun with BrightstarDB.
 ****************************************************
 
 Objects are composed of properties, each property is either a literal value 
-or a reference to another object. This creates a graph or related things with 
+or a reference to another object. This creates a graph of related things with 
 properties. ORM systems require that tables are organised in specific ways 
 to facilitate storing object state. Changes to either the object model or the 
 relational schema often require a reciprocal change. RDF on the other hand 
-can ideally be used to store both literal properties and object relationships 
-and if the object model needs to change then new property value can be added 
+can ideally be used to store both literal properties and object relationships; 
+if the object model needs to change then new property values can be added, 
 as there is no fixed schema. Similarly, if additional RDF data is added to 
 the store the object model can either ignore or make use of this data. In 
 this way the object model is an operational, read/write, view of the RDF data.


### PR DESCRIPTION
Corrected some small typos I found while reading the documentation a few months ago.